### PR TITLE
Fixing some errors on all-entries

### DIFF
--- a/client/components/Edit.jsx
+++ b/client/components/Edit.jsx
@@ -298,7 +298,8 @@ class Edit extends React.Component {
 
 		if (timeEntry) {
 			const isToday = areTheSameDay(moment(timeEntry.date), moment());
-			const labouredHoursOnDay = timeEntry.paidTime;
+			const labouredHoursOnDay = timeEntry.paidTime ||
+				calculateLabouredHours(timeEntry.storedTimes);
 			const hoursBalanceUpToDate = await this._getHoursBalanceValues(
 				date,
 				labouredHoursOnDay

--- a/client/components/Router.jsx
+++ b/client/components/Router.jsx
@@ -50,29 +50,28 @@ class ShowComponentOnRoute extends React.Component {
 			});
 	}
 
-	componentWillReceiveProps(nextProps) {
+	async componentWillReceiveProps(nextProps) {
 		const { userDetails, loading, error } = nextProps.userDetailsQuery;
 		if (error || (!loading && !userDetails)) {
 			removeAuthToken();
 			this.setState({ authenticated: false });
 		} else {
-		// Check if data on indexedDB
-		// it's never auth if indexedDB table is empty
-			DB('entries', 'date')
-				.then((db) => {
-					db.getAll()
-						.then((data) => {
-							if (data.length) {
-								this.setState({ authenticated: _checkAuth() });
-							}
-						})
-						.catch((e) => {
-							console.error('Router db detection error:', e);
-						});
-				})
-				.catch((e) => {
-					console.error('Check db error 1', e);
-				});
+			try {
+				// Check if data on indexedDB
+				// it's never auth if indexedDB table is empty
+				const db = await DB('entries', 'date')
+				const allEntries = await db.getAll();
+				if (allEntries.length) {
+					this.setState({ authenticated: _checkAuth() });
+				} else {
+					removeAuthToken();
+					this.setState({ authenticated: false });
+				}
+			} catch (e) {
+				removeAuthToken();
+				window.location.reload();
+				console.error(e);
+			}
 		}
 	}
 

--- a/client/components/Today.jsx
+++ b/client/components/Today.jsx
@@ -69,7 +69,7 @@ class Today extends React.Component {
 		}, 60000);
 		this.setState({ buttonDisabled: true });
 
-		const momentTime = { hours: moment().hours(), minutes: moment().minutes() };
+		const momentTime = { hours: moment().format('HH'), minutes: moment().format('mm') };
 		const index = this._getNextTimeEntryPoint();
 		const { storedTimes, sentToday } = this.state;
 		storedTimes[index] = momentTime;

--- a/client/components/Today.jsx
+++ b/client/components/Today.jsx
@@ -24,13 +24,12 @@ import {
 
 const MODAL_ALERT = 'alert';
 const MODAL_CONFIRM = 'confirm';
-const defaultStoredTimes = [{}, {}, {}, {}];
 
 class Today extends React.Component {
 	constructor() {
 		super();
 		this.state = {
-			storedTimes: [...defaultStoredTimes],
+			storedTimes: [{}, {}, {}, {}],
 			sentToday: false,
 			showModal: null,
 			alertInfo: {},
@@ -62,7 +61,7 @@ class Today extends React.Component {
 		}
 	}
 
-	onMark(event) {
+	async onMark(event) {
 		event.preventDefault();
 		// const this = this;
 		setTimeout(() => {
@@ -76,23 +75,17 @@ class Today extends React.Component {
 		storedTimes[index] = momentTime;
 
 		if (timeSetIsValid(storedTimes)) {
-			DB('entries', 'date')
-				.then((db) => {
-					// First fetch from DB and check if it's already there
-					db.put({ date: moment().format('YYYY-MM-DD'), storedTimes, sentToday })
-						.then(() => {
-							this.setState((prevState) => {
-								const newState = { ...prevState, storedTimes, sentToday };
-								if (index === 3) {
-									const date = moment();
-									submitToServer(date, storedTimes, this.props.addTimeEntry);
-								}
-								return newState;
-							});
-						})
-						.catch((er2) => { console.error('DB err:', er2); });
-				})
-				.catch((er1) => { console.error('DB err:', er1); });
+			const db = await DB('entries', 'date');
+			// Insert it to indexedDB and then insert set state. Also, if needed, send to server;
+			await db.put({ date: moment().format('YYYY-MM-DD'), storedTimes, sentToday });
+			this.setState((prevState) => {
+				const newState = { ...prevState, storedTimes, sentToday };
+				if (index === 3) {
+					const date = moment();
+					submitToServer(date, storedTimes, this.props.addTimeEntry);
+				}
+				return newState;
+			});
 		} else {
 			this.setState({
 				alertInfo: {
@@ -138,14 +131,14 @@ class Today extends React.Component {
 		const { timeEntry } = dayEntry;
 		if (timeEntry) {
 			const startTime = moment(timeEntry.startTime, 'H:mm');
-			const startBreakTime = moment(timeEntry.startBreakTime, 'H:mm');
-			const endBreakTime = moment(timeEntry.endBreakTime, 'H:mm');
+			const breakStartTime = moment(timeEntry.breakStartTime, 'H:mm');
+			const breakEndTime = moment(timeEntry.breakEndTime, 'H:mm');
 			const endTime = moment(timeEntry.endTime, 'H:mm');
 
 			// If data is on server
 			if (startTime.isValid() &&
-				startBreakTime.isValid() &&
-				endBreakTime.isValid() &&
+				breakStartTime.isValid() &&
+				breakEndTime.isValid() &&
 				endTime.isValid()
 			) {
 				const storedTimes = [
@@ -154,12 +147,12 @@ class Today extends React.Component {
 						minutes: startTime.minutes()
 					},
 					{
-						hours: startBreakTime.hours(),
-						minutes: startBreakTime.minutes()
+						hours: breakStartTime.hours(),
+						minutes: breakStartTime.minutes()
 					},
 					{
-						hours: endBreakTime.hours(),
-						minutes: endBreakTime.minutes()
+						hours: breakEndTime.hours(),
+						minutes: breakEndTime.minutes()
 					},
 					{
 						hours: endTime.hours(),

--- a/client/components/edit/ActiveDayTasks.jsx
+++ b/client/components/edit/ActiveDayTasks.jsx
@@ -18,17 +18,18 @@ const ActiveDayTasks = (props) => {
 		tabIndex,
 		disable,
 		onActivitySelect,
-		projectPhasesQuery
+		projectPhasesQuery,
+		isLoading
 	} = props;
 
 	const projectPhases = projectPhasesQuery.phases || {};
 
-	let textForProjectPhase = projectPhases.options ? null : strings.loading;
+	let textForProjectPhase = projectPhases.options || isLoading ? null : strings.loading;
 	if (projectPhases.options && projectPhases.options.length === 1) {
 		textForProjectPhase = projectPhases.options[0].name;
 	}
 
-	let textForActivity = projectPhases.options ? null : strings.loading;
+	let textForActivity = projectPhases.options || isLoading ? null : strings.loading;
 	if (isHoliday) {
 		textForActivity = SPECIAL_ACTIVITY_HOLIDAY.name;
 	}
@@ -69,11 +70,13 @@ ActiveDayTasks.propTypes = {
 	projectPhasesQuery: PropTypes.object.isRequired,
 	selectedActivity: PropTypes.object.isRequired,
 	selectedPhase: PropTypes.object.isRequired,
-	tabIndex: PropTypes.number
+	tabIndex: PropTypes.number,
+	isLoading: PropTypes.bool
 };
 
 ActiveDayTasks.defaultProps = {
 	disable: false,
 	isHoliday: false,
+	isLoading: false,
 	tabIndex: 0
 };

--- a/client/components/edit/MonthlyCalendar.jsx
+++ b/client/components/edit/MonthlyCalendar.jsx
@@ -8,6 +8,9 @@ import { isDayAfterToday } from '../../utils';
 
 import './MonthlyCalendar.styl';
 
+
+const isDayValid = day => (Boolean(day && day.paidTime && day.paidTime !== '0:00'));
+
 const _getStyleClassForCalendarDays = async () => {
 	let allEntries = [];
 	try {
@@ -25,7 +28,7 @@ const _getStyleClassForCalendarDays = async () => {
 	];
 	if (allEntries) {
 		allEntries.forEach((day) => {
-			const elementToPush = day.paidTime ?
+			const elementToPush = isDayValid(day) ?
 				dayStyles[0]['calendar-checked'] :
 				dayStyles[1]['calendar-unchecked'];
 
@@ -33,9 +36,6 @@ const _getStyleClassForCalendarDays = async () => {
 
 			elementToPush.push(dayMoment);
 
-			// if (isDayBlockedInPast(dayMoment)) {
-			// 	dayStyles[2]['calendar-locked'].push(dayMoment);
-			// }
 			if (isDayAfterToday(dayMoment)) {
 				dayStyles[3]['calendar-future-day'].push(dayMoment);
 			}

--- a/client/components/edit/WeeklyCalendar.jsx
+++ b/client/components/edit/WeeklyCalendar.jsx
@@ -43,8 +43,8 @@ const _storedTimesToDayEntry = (storedTimes, timeEntryAtIndex) => {
 		dayEntry = {
 			...timeEntryAtIndex,
 			startTime: new TimeDuration(_isEmptyObj(storedTimes[0])).toString(),
-			startBreakTime: new TimeDuration(_isEmptyObj(storedTimes[1])).toString(),
-			endBreakTime: new TimeDuration(_isEmptyObj(storedTimes[2])).toString(),
+			breakStartTime: new TimeDuration(_isEmptyObj(storedTimes[1])).toString(),
+			breakEndTime: new TimeDuration(_isEmptyObj(storedTimes[2])).toString(),
 			endTime: new TimeDuration(_isEmptyObj(storedTimes[3])).toString()
 		};
 	}
@@ -62,22 +62,22 @@ const _convertweekEntriesToEvents = (timeEntries, controlDate, storedTimes) => {
 
 			if (dayEntry) {
 				const hasBreak = Boolean((
-					dayEntry.startBreakTime &&
-					dayEntry.startBreakTime !== '0:00' &&
-					dayEntry.endBreakTime &&
-					dayEntry.endBreakTime !== '0:00'
+					dayEntry.breakStartTime &&
+					dayEntry.breakStartTime !== '0:00' &&
+					dayEntry.breakEndTime &&
+					dayEntry.breakEndTime !== '0:00'
 				));
 
 				if (hasBreak) {
 					events.push({
 						id: index * 2,
 						start: _getDateFromComposedObj(dayEntry, 'startTime'),
-						end: _getDateFromComposedObj(dayEntry, 'startBreakTime'),
+						end: _getDateFromComposedObj(dayEntry, 'breakStartTime'),
 						title: `${dayEntry.phase} - ${dayEntry.activity}`
 					});
 					events.push({
 						id: (index * 2) + 1,
-						start: _getDateFromComposedObj(dayEntry, 'endBreakTime'),
+						start: _getDateFromComposedObj(dayEntry, 'breakEndTime'),
 						end: _getDateFromComposedObj(dayEntry, 'endTime'),
 						title: `${dayEntry.phase} - ${dayEntry.activity}`
 					});

--- a/client/queries.graphql
+++ b/client/queries.graphql
@@ -16,8 +16,8 @@ mutation addTimeEntry($timeEntry: TimeEntryInput!) {
     addTimeEntry(timeEntry: $timeEntry) {
         date
         startTime
-        startBreakTime
-        endBreakTime
+        breakStartTime
+        breakEndTime
         endTime
         total
     }
@@ -27,8 +27,8 @@ mutation updateTimeEntry($timeEntry: TimeEntryInput!) {
     updateTimeEntry(timeEntry: $timeEntry) {
         date
         startTime
-        startBreakTime
-        endBreakTime
+        breakStartTime
+        breakEndTime
         endTime
         total
     }
@@ -41,8 +41,8 @@ query dayEntry($date: String!) {
             phase
             activity
             startTime
-            startBreakTime
-            endBreakTime
+            breakStartTime
+            breakEndTime
             endTime
             total
         }
@@ -75,8 +75,8 @@ query weekEntries($date: String!) {
             phase
             activity
             startTime
-            startBreakTime
-            endBreakTime
+            breakStartTime
+            breakEndTime
             endTime
             total
         }

--- a/client/utils.js
+++ b/client/utils.js
@@ -289,3 +289,17 @@ export const getTimeEntriesForWeek = async (choosenDay) => {
 	const timeEntries = await Promise.all(promisses);
 	return timeEntries;
 };
+
+export const isControlDatePersisted = async (controlDate) => {
+	try {
+		const db = await DB('entries', 'date');
+		const entry = await db.getEntry(controlDate.format('YYYY-MM-DD'));
+		if (areTheSameDay(controlDate, moment())) {
+			return Boolean(entry && entry.sentToday);
+		}
+		return Boolean(entry && entry.contractedTime);
+	} catch (e) {
+		console.error(e);
+		return false;
+	}
+};

--- a/client/utils.js
+++ b/client/utils.js
@@ -13,8 +13,8 @@ export const STORAGEKEY = 'storedTimes';
 export const STORAGEDAYKEY = 'storedMoment';
 export const storedTimesIndex = {
 	startTime: 0,
-	startBreakTime: 1,
-	endBreakTime: 2,
+	breakStartTime: 1,
+	breakEndTime: 2,
 	endTime: 3
 };
 export const SPECIAL_ACTIVITY_HOLIDAY = { id: 99999, name: 'Holiday' };
@@ -122,8 +122,8 @@ const _addTimeEntry = async (timeEntryInput, addTimeEntry) => {
  */
 export const submitToServer = async (date, stateStoredTimes, phase, activity, addTimeEntry) => {
 	const startTime = stateStoredTimes[storedTimesIndex.startTime];
-	const startBreakTime = stateStoredTimes[storedTimesIndex.startBreakTime];
-	const endBreakTime = stateStoredTimes[storedTimesIndex.endBreakTime];
+	const breakStartTime = stateStoredTimes[storedTimesIndex.breakStartTime];
+	const breakEndTime = stateStoredTimes[storedTimesIndex.breakEndTime];
 	const endTime = stateStoredTimes[storedTimesIndex.endTime];
 
 	const timeEntryInput = {
@@ -131,8 +131,8 @@ export const submitToServer = async (date, stateStoredTimes, phase, activity, ad
 		phaseId: phase.id,
 		activityId: activity.id,
 		startTime: `${startTime.hours}:${startTime.minutes}`,
-		startBreakTime: `${startBreakTime.hours}:${startBreakTime.minutes}`,
-		endBreakTime: `${endBreakTime.hours}:${endBreakTime.minutes}`,
+		breakStartTime: `${breakStartTime.hours}:${breakStartTime.minutes}`,
+		breakEndTime: `${breakEndTime.hours}:${breakEndTime.minutes}`,
 		endTime: `${endTime.hours}:${endTime.minutes}`
 	};
 
@@ -147,14 +147,14 @@ export const submitToServer = async (date, stateStoredTimes, phase, activity, ad
  */
 export const calculateLabouredHours = (storedTimes) => {
 	const startTime = storedTimes[storedTimesIndex.startTime];
-	const startBreakTime = storedTimes[storedTimesIndex.startBreakTime];
-	const endBreakTime = storedTimes[storedTimesIndex.endBreakTime];
+	const breakStartTime = storedTimes[storedTimesIndex.breakStartTime];
+	const breakEndTime = storedTimes[storedTimesIndex.breakEndTime];
 	const endTime = storedTimes[storedTimesIndex.endTime];
 
 	const labouredHoursOnDay = new TimeDuration();
 	labouredHoursOnDay.add(endTime);
-	labouredHoursOnDay.subtract(endBreakTime);
-	labouredHoursOnDay.add(startBreakTime);
+	labouredHoursOnDay.subtract(breakEndTime);
+	labouredHoursOnDay.add(breakStartTime);
 	labouredHoursOnDay.subtract(startTime);
 
 	return labouredHoursOnDay.toString();
@@ -256,20 +256,20 @@ const indexedDBToTimeEntry = async (database, stringOfDateQuery) => {
 		{
 			activity: '',		// For the uses now, this doesn't matter
 			date: stringOfDateQuery,
-			endBreakTime: indexedDbQuery.breakEndTime,
+			breakEndTime: indexedDbQuery.breakEndTime,
 			endTime: indexedDbQuery.endTime,
 			phase: '',
-			startBreakTime: indexedDbQuery.breakStartTime,
+			breakStartTime: indexedDbQuery.breakStartTime,
 			startTime: indexedDbQuery.startTime,
 			total: indexedDbQuery.paidTime
 		} :
 		{
 			activity: '',
 			date: stringOfDateQuery,
-			endBreakTime: '',
+			breakEndTime: '',
 			endTime: '',
 			phase: '',
-			startBreakTime: '',
+			breakStartTime: '',
 			startTime: '',
 			total: ''
 		};

--- a/package-lock.json
+++ b/package-lock.json
@@ -7345,7 +7345,7 @@
     },
     "moment-timezone": {
       "version": "0.5.14",
-      "resolved": "http://127.0.0.1:4873/moment-timezone/-/moment-timezone-0.5.14.tgz",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
       "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
       "requires": {
         "moment": "2.20.1"

--- a/server/api/middleware.js
+++ b/server/api/middleware.js
@@ -140,7 +140,7 @@ const getBalance = ($) => {
 };
 
 const allTimesTableToData = ($) => {
-	const data = [];
+	const data = [{ date: '1969-01-01' }];
 	const trimmedText = element => $(element).text().trim();
 	$('#all_records table tr').each((i, tr) => {
 		const tds = $(tr).find('td');
@@ -211,8 +211,8 @@ const dailyEntries = date => async (token) => {
 	} = workTimeFromHtml($);
 	const {
 		breakTimeId,
-		startBreakTime,
-		endBreakTime,
+		breakStartTime,
+		breakEndTime,
 		breakTimeDuration
 	} = breakTimeFromHtml($);
 
@@ -249,8 +249,8 @@ const dailyEntries = date => async (token) => {
 		activity,
 		startTime: (isValid && startTime) || '',
 		endTime: (isValid && endTime) || '',
-		startBreakTime: (isValid && startBreakTime) || '',
-		endBreakTime: (isValid && endBreakTime) || '',
+		breakStartTime: (isValid && breakStartTime) || '',
+		breakEndTime: (isValid && breakEndTime) || '',
 		total: (isValid && newTotal) || ''
 	};
 

--- a/server/api/utils.js
+++ b/server/api/utils.js
@@ -51,8 +51,8 @@ const extractBreakTime = (response) => {
 
 	if (times && times.length > 2) {
 		return {
-			startBreakTime: times[1],
-			endBreakTime: times[2]
+			breakStartTime: times[1],
+			breakEndTime: times[2]
 		};
 	}
 
@@ -119,12 +119,12 @@ const breakTimeFromHtml = ($) => {
 	const breakTimeDuration = $('table tr.yellow td').eq(3).text().trim();
 	const breakTime = $('table tr.yellow td').eq(1).text().trim();
 
-	const { startBreakTime, endBreakTime } = extractBreakTime(breakTime);
+	const { breakStartTime, breakEndTime } = extractBreakTime(breakTime);
 
 	return {
 		breakTimeId,
-		startBreakTime,
-		endBreakTime,
+		breakStartTime,
+		breakEndTime,
 		breakTimeDuration
 	};
 };
@@ -147,8 +147,8 @@ const activityToPayload = (timeEntry, phaseId, activityId) => {
 	const date = moment(timeEntry.date);
 	const startTime = moment(timeEntry.startTime, 'H:mm');
 	const endTime = moment(timeEntry.endTime, 'H:mm');
-	const startBreakTime = moment(timeEntry.startBreakTime || '12:00', 'H:mm');
-	const endBreakTime = moment(timeEntry.endBreakTime || '13:00', 'H:mm');
+	const breakStartTime = moment(timeEntry.breakStartTime || '12:00', 'H:mm');
+	const breakEndTime = moment(timeEntry.breakEndTime || '13:00', 'H:mm');
 
 	const totalWorkedTime = moment().startOf('day');
 
@@ -163,13 +163,13 @@ const activityToPayload = (timeEntry, phaseId, activityId) => {
 	});
 
 	totalWorkedTime.add({
-		hours: startBreakTime.hours(),
-		minutes: startBreakTime.minutes()
+		hours: breakStartTime.hours(),
+		minutes: breakStartTime.minutes()
 	});
 
 	totalWorkedTime.subtract({
-		hours: endBreakTime.hours(),
-		minutes: endBreakTime.minutes()
+		hours: breakEndTime.hours(),
+		minutes: breakEndTime.minutes()
 	});
 
 	return {
@@ -181,8 +181,8 @@ const activityToPayload = (timeEntry, phaseId, activityId) => {
 		anoi: date.year(),
 		timehH: startTime.hours(),
 		timemH: startTime.minutes(),
-		startBreak6: timeEntry.startBreakTime || '12:00',
-		endBreak6: timeEntry.endBreakTime || '13:00',
+		startBreak6: timeEntry.breakStartTime || '12:00',
+		endBreak6: timeEntry.breakEndTime || '13:00',
 		timeh: totalWorkedTime.hours(),
 		timem: totalWorkedTime.minutes()
 	};

--- a/server/cli/utils.js
+++ b/server/cli/utils.js
@@ -7,7 +7,7 @@ const logger = require('../logger');
 const strings = require('../../shared/strings');
 const { sendActivity } = require('./calls');
 
-const timeKeys = ['startTime', 'startBreakTime', 'endBreakTime', 'endTime'];
+const timeKeys = ['startTime', 'breakStartTime', 'breakEndTime', 'endTime'];
 
 const STORAGE_KEY = 'storedTimes';
 storage.initSync({ dir: 'server/temp' });

--- a/server/schema/index.js
+++ b/server/schema/index.js
@@ -6,8 +6,8 @@ const typeDefs = `
 		date: String!,
 		startTime: String!,
 		endTime: String!,
-		startBreakTime: String,
-		endBreakTime: String,
+		breakStartTime: String,
+		breakEndTime: String,
 		phaseId: Int,
 		activityId: Int
 	}
@@ -24,8 +24,8 @@ const typeDefs = `
 		activity: String,
 		startTime: String,
 		endTime: String,
-		startBreakTime: String,
-		endBreakTime: String,
+		breakStartTime: String,
+		breakEndTime: String,
 		total: String
 	}
 


### PR DESCRIPTION
 - Using Async/Await instead then|catch where it was in use
 - Fix Activity propagation and using time from indexedDB and not from dayQuery
 - Minor Fix for '00' time
 - Persisted on server fix (showing Send or Update)
 - Using loading only on activity and not on entire page
 - Fix valid day: Disallowing 0:00 time
 - Renamed and standardized (start|end)Breaktime to break(Start|End)Time
 - Not allowing empty indexedDB if logged in and fix for new employees that do not have populate data 